### PR TITLE
Clean up reader timer on unmount

### DIFF
--- a/ProofofReading.svelte
+++ b/ProofofReading.svelte
@@ -21,9 +21,15 @@ Historians point out that rationing systems are often perceived as unfair in the
 
   let evidence: Evidence[] = [];
   let dwellMs = 0;
-  let timer: any;
-  onMount(() => { timer = setInterval(() => (dwellMs += 1000), 1000); });
-  function destroy() { clearInterval(timer); }
+  onMount(() => {
+    const interval = setInterval(() => {
+      dwellMs += 1000;
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  });
 
   function percentDone() { return Math.round((tasks.filter((t) => t.done).length / tasks.length) * 100); }
 


### PR DESCRIPTION
## Summary
- clear the proof-of-reading dwell timer when the component unmounts by returning a cleanup callback
- remove the unused destroy helper now that the lifecycle handles the interval

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf5bcd12388323aa04a4b09c496469