### PR TITLE
Ensure setAnswer updates tasks immutably

### DIFF
--- a/ProofofReading.svelte
+++ b/ProofofReading.svelte
@@ -54,10 +54,10 @@ Historians point out that rationing systems are often perceived as unfair in the
   }
 
   function setAnswer(id: string, val: string) {
-    const t = tasks.find((x) => x.id === id);
-    if (!t) return;
-    t.answer = val;
-    t.done = (val || '').trim().length > 3;
+    const trimmed = (val ?? '').trim();
+    tasks = tasks.map((task) =>
+      task.id === id ? { ...task, answer: val, done: trimmed.length > 3 } : task
+    );
   }
 
   // ---------- Teacher data ----------


### PR DESCRIPTION
## Summary
- update the student task answer helper to immutably replace the updated task entry
- continue trimming input before marking tasks complete so progress reacts immediately

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf5bc57e888323bd868d627b5c431a