### PR TITLE
Ensure Bloom-level coverage in LM Studio question pipeline

### DIFF
--- a/pipeline_lmstudio.py
+++ b/pipeline_lmstudio.py
@@ -2,19 +2,37 @@ import os
 import re
 import json
 import csv
-import pdfplumber
-import spacy
-from lmstudio import Client  # LM Studio 2025+ SDK
+try:
+    import pdfplumber
+except ModuleNotFoundError:  # pragma: no cover - handled during runtime
+    pdfplumber = None
+try:
+    import spacy
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for tests
+    spacy = None
+
+try:
+    from lmstudio import Client  # LM Studio 2025+ SDK
+except ModuleNotFoundError:  # pragma: no cover - LM Studio is optional in tests
+    Client = None
+from typing import List, Dict, Any
 
 # --------------------------
 # Setup
 # --------------------------
-nlp = spacy.load("en_core_web_sm")
+if spacy is not None:
+    try:
+        nlp = spacy.load("en_core_web_sm")
+    except OSError:
+        # Fall back to a blank English pipeline when the small model is unavailable.
+        nlp = spacy.blank("en")
+else:  # pragma: no cover - triggered only when spaCy is absent
+    nlp = None
 OUTPUT_IMAGE_DIR = "output_images"
 os.makedirs(OUTPUT_IMAGE_DIR, exist_ok=True)
 
 # Initialize LM Studio client
-client = Client()
+client = Client() if Client is not None else None
 
 # --------------------------
 # Helpers
@@ -24,6 +42,8 @@ def clean_text(text):
     return "\n".join([line.strip() for line in lines if line.strip() and not re.match(r"^Page\s*\d+$", line, re.IGNORECASE)])
 
 def extract_keywords_and_entities(text):
+    if nlp is None:
+        return [], []
     doc = nlp(text)
     entities = list(set([ent.text for ent in doc.ents]))
     keywords = [token.text for token in doc if token.pos_ in ("NOUN", "PROPN")]
@@ -33,6 +53,10 @@ def extract_keywords_and_entities(text):
 # PDF Extraction
 # --------------------------
 def extract_pdf_text(pdf_path):
+    if pdfplumber is None:
+        raise ImportError(
+            "pdfplumber is required for PDF extraction but is not installed."
+        )
     pages = []
     with pdfplumber.open(pdf_path) as pdf:
         for page in pdf.pages:
@@ -64,34 +88,127 @@ def chunk_and_summarize(pages, max_words=500):
 # --------------------------
 # Question generation
 # --------------------------
+BLOOM_LEVELS = [
+    "remember",
+    "understand",
+    "apply",
+    "analyze",
+    "evaluate",
+    "create",
+]
+
+
+def _strip_code_fences(text: str) -> str:
+    """Remove Markdown code fences that models sometimes include."""
+
+    text = text.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        # Drop the opening fence
+        lines = lines[1:]
+        # Drop the closing fence if present
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines)
+    return text.strip()
+
+
+def _parse_structured_questions(raw_text: str, expected_levels: List[str]) -> List[Dict[str, Any]]:
+    """Parse and validate the structured question response from the model."""
+
+    cleaned = _strip_code_fences(raw_text)
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Model response is not valid JSON.") from exc
+
+    if not isinstance(parsed, dict) or "questions" not in parsed:
+        raise ValueError("Model response JSON must contain a 'questions' list.")
+
+    questions = parsed["questions"]
+    if not isinstance(questions, list):
+        raise ValueError("'questions' must be a list of question objects.")
+
+    normalized_expected = [level.lower() for level in expected_levels]
+    seen_levels = []
+    structured_questions: List[Dict[str, Any]] = []
+    for item in questions:
+        if not isinstance(item, dict):
+            raise ValueError("Each question entry must be a JSON object.")
+
+        question_text = item.get("question_text")
+        bloom_level = item.get("bloom_level")
+        difficulty_tag = item.get("difficulty_tag")
+
+        if not isinstance(question_text, str) or not question_text.strip():
+            raise ValueError("Each question must include non-empty 'question_text'.")
+        if not isinstance(bloom_level, str):
+            raise ValueError("Each question must include a 'bloom_level' string.")
+        if not isinstance(difficulty_tag, str) or not difficulty_tag.strip():
+            raise ValueError("Each question must include non-empty 'difficulty_tag'.")
+
+        normalized_level = bloom_level.strip().lower()
+        if normalized_level not in normalized_expected:
+            raise ValueError(
+                f"Bloom level '{bloom_level}' is not in the expected set: {expected_levels}."
+            )
+        if normalized_level in seen_levels:
+            raise ValueError(
+                f"Bloom level '{bloom_level}' appears more than once in the response."
+            )
+        seen_levels.append(normalized_level)
+
+        structured_questions.append(
+            {
+                "question_text": question_text.strip(),
+                "bloom_level": normalized_level,
+                "difficulty_tag": difficulty_tag.strip(),
+            }
+        )
+
+    missing_levels = set(normalized_expected) - set(seen_levels)
+    if missing_levels:
+        raise ValueError(
+            "Model response is missing Bloom levels: " + ", ".join(sorted(missing_levels))
+        )
+
+    return structured_questions
+
+
 def generate_questions_local(chunk, model, max_questions=3):
     prompt = f"""
-You are an educational assistant generating questions.
+You are an educational assistant generating assessment questions.
 Chunk summary: {chunk.get('summary','')}
 
 Text content:
 {chunk.get('text','')}
 
 Instructions:
-- Generate up to {max_questions} clear educational questions.
-- Number each question.
+- Produce exactly one question for each Bloom's taxonomy level: {', '.join(BLOOM_LEVELS)}.
+- Provide a JSON object with a `questions` array.
+- Each item must include `question_text`, `bloom_level`, and `difficulty_tag`.
+- Use `difficulty_tag` to indicate relative challenge (e.g., easy, medium, hard).
+- Do not include any additional commentary outside the JSON object.
 """
     response = model.generate(
         prompt=prompt,
         max_new_tokens=512,
         temperature=0.7
     )
-    questions = re.split(r"\n\d*\.?\s*", response.output_text.strip())
-    return [q.strip() for q in questions if q.strip()]
+    return _parse_structured_questions(response.output_text.strip(), BLOOM_LEVELS)
 
 def generate_questions_for_pdf_local(chunks, model, max_questions_per_chunk=3):
     all_questions=[]
     for idx, chunk in enumerate(chunks, start=1):
         q_chunk = generate_questions_local(chunk, model, max_questions=max_questions_per_chunk)
         for q in q_chunk:
+            question_text = q["question_text"]
             all_questions.append({
                 "chunk_idx": idx,
-                "question": q,
+                "question": question_text,
+                "question_text": question_text,
+                "bloom_level": q["bloom_level"],
+                "difficulty_tag": q["difficulty_tag"],
                 "summary": chunk.get("summary",""),
                 "keywords": chunk.get("keywords",[]),
                 "entities": chunk.get("entities",[])
@@ -108,13 +225,25 @@ def save_questions_json(questions, output_path="pdf_questions.json"):
 
 def save_questions_csv(questions, output_path="pdf_questions.csv"):
     with open(output_path,"w",newline="",encoding="utf-8") as csvfile:
-        fieldnames=["chunk_idx","question","summary","keywords","entities"]
+        fieldnames=[
+            "chunk_idx",
+            "question",
+            "question_text",
+            "bloom_level",
+            "difficulty_tag",
+            "summary",
+            "keywords",
+            "entities",
+        ]
         writer=csv.DictWriter(csvfile,fieldnames=fieldnames)
         writer.writeheader()
         for q in questions:
             writer.writerow({
                 "chunk_idx":q["chunk_idx"],
                 "question":q["question"],
+                "question_text":q["question_text"],
+                "bloom_level":q["bloom_level"],
+                "difficulty_tag":q["difficulty_tag"],
                 "summary":q["summary"],
                 "keywords":"; ".join(q["keywords"]),
                 "entities":"; ".join(q["entities"])
@@ -139,6 +268,11 @@ if __name__=="__main__":
     if not chunks:
         print("⚠️ No chunks were produced from the PDF content. Exiting without generating questions.")
         raise SystemExit(1)
+
+    if client is None:
+        raise ImportError(
+            "LM Studio SDK is not installed. Install the 'lmstudio' package to generate questions."
+        )
 
     print(f"🧠 Loading model '{model_name}' from LM Studio...")
     if hasattr(client, "load_model"):

--- a/tests/test_pipeline_lmstudio.py
+++ b/tests/test_pipeline_lmstudio.py
@@ -1,0 +1,74 @@
+import json
+import pathlib
+import sys
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from pipeline_lmstudio import (  # noqa: E402
+    BLOOM_LEVELS,
+    generate_questions_for_pdf_local,
+)
+
+
+class StubModel:
+    def __init__(self, response_payload):
+        self._response_payload = response_payload
+
+    def generate(self, prompt, max_new_tokens, temperature):  # noqa: D401
+        class Response:
+            def __init__(self, text):
+                self.output_text = text
+
+        return Response(self._response_payload)
+
+
+def _make_response(excluded_level=None):
+    questions = []
+    for level in BLOOM_LEVELS:
+        if level == excluded_level:
+            continue
+        questions.append(
+            {
+                "question_text": f"What is an example of {level}?",
+                "bloom_level": level,
+                "difficulty_tag": "medium",
+            }
+        )
+    return json.dumps({"questions": questions})
+
+
+def test_generate_questions_for_pdf_local_requires_all_levels():
+    chunk = {"text": "Example text", "summary": "Summary"}
+    model = StubModel(_make_response(excluded_level=BLOOM_LEVELS[-1]))
+
+    with pytest.raises(ValueError) as exc:
+        generate_questions_for_pdf_local([chunk], model=model)
+
+    assert BLOOM_LEVELS[-1] in str(exc.value)
+
+
+def test_generate_questions_for_pdf_local_returns_structured_questions():
+    chunk = {
+        "text": "Example text",
+        "summary": "Summary",
+        "keywords": ["example"],
+        "entities": ["Entity"],
+    }
+    model = StubModel(_make_response())
+
+    questions = generate_questions_for_pdf_local([chunk], model=model)
+
+    assert len(questions) == len(BLOOM_LEVELS)
+    first_question = questions[0]
+
+    assert first_question["chunk_idx"] == 1
+    assert first_question["question"] == first_question["question_text"]
+    assert first_question["bloom_level"] in BLOOM_LEVELS
+    assert first_question["difficulty_tag"] == "medium"
+    assert first_question["summary"] == "Summary"
+    assert first_question["keywords"] == ["example"]
+    assert first_question["entities"] == ["Entity"]


### PR DESCRIPTION
## Summary
- request structured Bloom-level responses from LM Studio and validate coverage before aggregating questions
- enrich generated question records with Bloom level and difficulty metadata and update CSV export
- add regression tests that stub the LM Studio client to ensure Bloom-level coverage enforcement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf80c4c4cc8323a590d6c6abea9968