### PR TITLE
Improve focus rings across question and reader panels

### DIFF
--- a/src/lib/epub/EpubReader.svelte
+++ b/src/lib/epub/EpubReader.svelte
@@ -343,6 +343,14 @@
     cursor: pointer;
   }
 
+  .control:focus {
+    outline: none;
+  }
+
+  .control:focus-visible {
+    box-shadow: 0 0 0 4px rgba(195, 212, 255, 0.85);
+  }
+
   .control[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
@@ -372,8 +380,12 @@
 
   .toc-item button:focus {
     outline: none;
-    border-color: #7c9cff;
+  }
+
+  .toc-item button:focus-visible {
+    border-color: rgba(124, 156, 255, 0.75);
     background: rgba(124, 156, 255, 0.2);
+    box-shadow: 0 0 0 4px rgba(124, 156, 255, 0.55);
   }
 
   .toc-item.level-2 { padding-left: 16px; }
@@ -413,8 +425,12 @@
 
   .search-results button:focus {
     outline: none;
-    border-color: #7c9cff;
+  }
+
+  .search-results button:focus-visible {
+    border-color: rgba(124, 156, 255, 0.75);
     background: rgba(124, 156, 255, 0.2);
+    box-shadow: 0 0 0 4px rgba(124, 156, 255, 0.55);
   }
 
   .status-bar {

--- a/src/lib/questions/NewQuestionPanel.svelte
+++ b/src/lib/questions/NewQuestionPanel.svelte
@@ -133,23 +133,30 @@
     align-items: center;
     gap: 0.5rem;
     font-size: 1rem;
-    padding: 0.25rem 0;
+    padding: 0.25rem 0.25rem;
     background: none;
     border: none;
     color: inherit;
     text-align: left;
     cursor: pointer;
-  }
-
-  .hint-toggle:focus-visible {
-    outline: 3px solid var(--focus-ring, #2563eb);
-    outline-offset: 2px;
+    border-radius: 0.75rem;
   }
 
   .answer-toggle {
     margin-top: 1rem;
     font-size: 1rem;
     padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+  }
+
+  .hint-toggle:focus,
+  .answer-toggle:focus {
+    outline: none;
+  }
+
+  .hint-toggle:focus-visible,
+  .answer-toggle:focus-visible {
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.55);
   }
 
   .answer-panel,

--- a/src/lib/teacher/QuestionPanel.svelte
+++ b/src/lib/teacher/QuestionPanel.svelte
@@ -221,7 +221,11 @@
   }
 
   .tab:focus {
-    outline: 2px solid #7c9cff;
+    outline: none;
+  }
+
+  .tab:focus-visible {
+    outline: 4px solid rgba(195, 212, 255, 0.9);
     outline-offset: 2px;
   }
 
@@ -282,8 +286,11 @@
   }
 
   .chip:focus {
-    outline: 2px solid #7c9cff;
-    outline-offset: 2px;
+    outline: none;
+  }
+
+  .chip:focus-visible {
+    box-shadow: 0 0 0 4px rgba(124, 156, 255, 0.6);
   }
 
   .chip.active {


### PR DESCRIPTION
## Summary
- increase the teacher question tabs and chips focus-visible treatment to a high-contrast 4px ring
- adjust the new question hint/answer toggles to use a consistent 4px box-shadow ring without shifting layout
- restore 4px focus-visible rings for reader controls, TOC items, and search results to maintain keyboard visibility

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68cf86ac55488323aba3d8953a55fa58