### PR TITLE
Ensure primary controls meet touch target sizing

### DIFF
--- a/ProofofReading.svelte
+++ b/ProofofReading.svelte
@@ -396,7 +396,26 @@
   .student-grid.single-column .separator-handle { display: none; }
   .title { font-size: 1.25rem; font-weight: 700; }
   .muted { color: #9aa3b2; }
-  .btn { background: #7c9cff; color:#0b1020; border:none; padding:10px 14px; border-radius:10px; font-weight:700; cursor:pointer; }
+  .btn {
+    background: #7c9cff;
+    color: #0b1020;
+    border: none;
+    padding: 12px 16px;
+    border-radius: 10px;
+    font-weight: 700;
+    cursor: pointer;
+    min-height: 44px;
+    min-width: 44px;
+    line-height: 1.2;
+  }
+
+  button.btn,
+  a.btn,
+  .btn[role='button'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
   .btn.secondary { background: rgba(255,255,255,.08); color: #e6e9ef; }
   .pill { display:inline-block; padding: 2px 8px; border-radius:999px; background: rgba(255,255,255,.06); font-size:12px; }
   .table { width:100%; border-collapse: collapse; }

--- a/src/lib/epub/EpubReader.svelte
+++ b/src/lib/epub/EpubReader.svelte
@@ -332,16 +332,19 @@
     display: flex;
     gap: 8px;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   .control {
     background: #7c9cff;
     color: #0b1020;
     border: none;
-    padding: 8px 12px;
+    padding: 10px 14px;
     border-radius: 8px;
     font-weight: 600;
     cursor: pointer;
+    min-height: 44px;
+    min-width: 44px;
   }
 
   .control:focus {


### PR DESCRIPTION
## Summary
- bump EPUB reader toolbar control sizing and allow wrapping so touch targets stay reachable on narrow viewports
- increase shared button styling in the proof-of-reading demo to meet 44px minimum height while keeping layout alignment for CTA buttons

## Testing
- not run (not available in repo)


------
https://chatgpt.com/codex/tasks/task_e_68cf897c13288323b68fc94cee6daa1c