### PR TITLE
Add shared keyboard handler for question toggles

### DIFF
--- a/src/lib/questions/NewQuestionPanel.svelte
+++ b/src/lib/questions/NewQuestionPanel.svelte
@@ -35,6 +35,17 @@
   const toggleAnswer = (id: string) => {
     openAnswers = toggleSet(openAnswers, id);
   };
+
+  const handleToggleKeydown = (
+    event: KeyboardEvent,
+    id: string,
+    toggle: (itemId: string) => void
+  ) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle(id);
+    }
+  };
 </script>
 
 <section class="new-question-panel">
@@ -53,6 +64,7 @@
               aria-expanded={openHints.has(question.id)}
               aria-controls={`${question.id}-hint-panel`}
               on:click={() => toggleHint(question.id)}
+              on:keydown={(event) => handleToggleKeydown(event, question.id, toggleHint)}
             >
               {openHints.has(question.id) ? 'Hide hint' : 'Show hint'}
             </button>
@@ -79,6 +91,7 @@
           aria-expanded={openAnswers.has(question.id)}
           aria-controls={`${question.id}-answer-panel`}
           on:click={() => toggleAnswer(question.id)}
+          on:keydown={(event) => handleToggleKeydown(event, question.id, toggleAnswer)}
         >
           {openAnswers.has(question.id) ? 'Hide answer' : 'Show answer'}
         </button>


### PR DESCRIPTION
## Summary
- add a shared keyboard handler that triggers the hint and answer toggles on Enter/Space
- prevent the default key behavior to avoid double toggles when activating with the keyboard

## Testing
- npx vitest run src/lib/questions/__tests__/NewQuestionPanel.test.ts *(fails: Vitest config parsing error in vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa1937fd483238074de02767093d4