### PR TITLE
test: add vitest globals import for new question panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,2289 +1,4576 @@
 {
 
+  "name": "Ebook",
+
   "version": "1.0.0",
+
   "lockfileVersion": 3,
+
   "requires": true,
+
   "packages": {
+
     "": {
 
       "version": "1.0.0",
+
       "devDependencies": {
+
         "@sveltejs/adapter-auto": "^3.3.1",
+
         "@sveltejs/kit": "^2.42.2",
+
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
+
         "@testing-library/jest-dom": "^6.5.0",
+
         "@testing-library/svelte": "^5.2.4",
+
         "@testing-library/user-event": "^14.5.2",
+
         "@vitest/ui": "^3.2.4",
+
         "happy-dom": "^13.10.1",
+
         "svelte": "^4.2.20",
+
         "typescript": "^5.6.3",
+
         "vite": "^5.4.20",
+
         "vitest": "^3.2.4"
+
       }
+
     },
+
     "node_modules/@adobe/css-tools": {
+
       "version": "4.4.4",
+
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@ampproject/remapping": {
+
       "version": "2.3.0",
+
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+
       "dev": true,
+
       "license": "Apache-2.0",
+
       "dependencies": {
+
         "@jridgewell/gen-mapping": "^0.3.5",
+
         "@jridgewell/trace-mapping": "^0.3.24"
+
       },
+
       "engines": {
+
         "node": ">=6.0.0"
+
       }
+
     },
+
     "node_modules/@babel/code-frame": {
+
       "version": "7.27.1",
+
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@babel/helper-validator-identifier": "^7.27.1",
+
         "js-tokens": "^4.0.0",
+
         "picocolors": "^1.1.1"
+
       },
+
       "engines": {
+
         "node": ">=6.9.0"
+
       }
+
     },
+
     "node_modules/@babel/helper-validator-identifier": {
+
       "version": "7.27.1",
+
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6.9.0"
+
       }
+
     },
+
     "node_modules/@babel/runtime": {
+
       "version": "7.28.4",
+
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6.9.0"
+
       }
+
     },
+
     "node_modules/@esbuild/aix-ppc64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+
       "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+
       "cpu": [
+
         "ppc64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "aix"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/android-arm": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+
       "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+
       "cpu": [
+
         "arm"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "android"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/android-arm64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+
       "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "android"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/android-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+
       "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "android"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/darwin-arm64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+
       "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "darwin"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/darwin-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+
       "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "darwin"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/freebsd-arm64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+
       "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "freebsd"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/freebsd-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+
       "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "freebsd"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-arm": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+
       "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+
       "cpu": [
+
         "arm"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-arm64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+
       "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-ia32": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+
       "cpu": [
+
         "ia32"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-loong64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+
       "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+
       "cpu": [
+
         "loong64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-mips64el": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+
       "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+
       "cpu": [
+
         "mips64el"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-ppc64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+
       "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+
       "cpu": [
+
         "ppc64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-riscv64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+
       "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+
       "cpu": [
+
         "riscv64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-s390x": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+
       "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+
       "cpu": [
+
         "s390x"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/linux-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+
       "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/netbsd-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+
       "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "netbsd"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/openbsd-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+
       "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "openbsd"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/sunos-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+
       "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "sunos"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/win32-arm64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+
       "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/win32-ia32": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+
       "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+
       "cpu": [
+
         "ia32"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@esbuild/win32-x64": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ],
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/@jridgewell/gen-mapping": {
+
       "version": "0.3.13",
+
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@jridgewell/sourcemap-codec": "^1.5.0",
+
         "@jridgewell/trace-mapping": "^0.3.24"
+
       }
+
     },
+
     "node_modules/@jridgewell/resolve-uri": {
+
       "version": "3.1.2",
+
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6.0.0"
+
       }
+
     },
+
     "node_modules/@jridgewell/sourcemap-codec": {
+
       "version": "1.5.5",
+
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@jridgewell/trace-mapping": {
+
       "version": "0.3.31",
+
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@jridgewell/resolve-uri": "^3.1.0",
+
         "@jridgewell/sourcemap-codec": "^1.4.14"
+
       }
+
     },
+
     "node_modules/@polka/url": {
+
       "version": "1.0.0-next.29",
+
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@rollup/rollup-android-arm-eabi": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz",
+
       "integrity": "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==",
+
       "cpu": [
+
         "arm"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "android"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-android-arm64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz",
+
       "integrity": "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "android"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-darwin-arm64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz",
+
       "integrity": "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "darwin"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-darwin-x64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz",
+
       "integrity": "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "darwin"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-freebsd-arm64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz",
+
       "integrity": "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "freebsd"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-freebsd-x64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz",
+
       "integrity": "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "freebsd"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz",
+
       "integrity": "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==",
+
       "cpu": [
+
         "arm"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz",
+
       "integrity": "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==",
+
       "cpu": [
+
         "arm"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-arm64-musl": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz",
+
       "integrity": "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==",
+
       "cpu": [
+
         "loong64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==",
+
       "cpu": [
+
         "ppc64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==",
+
       "cpu": [
+
         "riscv64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz",
+
       "integrity": "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==",
+
       "cpu": [
+
         "riscv64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz",
+
       "integrity": "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==",
+
       "cpu": [
+
         "s390x"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-x64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-linux-x64-musl": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz",
+
       "integrity": "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "linux"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-openharmony-arm64": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz",
+
       "integrity": "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "openharmony"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz",
+
       "integrity": "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==",
+
       "cpu": [
+
         "arm64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz",
+
       "integrity": "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==",
+
       "cpu": [
+
         "ia32"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-win32-x64-gnu": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz",
+
       "integrity": "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ]
+
     },
+
     "node_modules/@rollup/rollup-win32-x64-msvc": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz",
+
       "integrity": "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==",
+
       "cpu": [
+
         "x64"
+
       ],
+
       "dev": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "win32"
+
       ]
+
     },
+
     "node_modules/@standard-schema/spec": {
+
       "version": "1.0.0",
+
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@sveltejs/acorn-typescript": {
+
       "version": "1.0.5",
+
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+
       "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "peerDependencies": {
+
         "acorn": "^8.9.0"
+
       }
+
     },
+
     "node_modules/@sveltejs/adapter-auto": {
+
       "version": "3.3.1",
+
       "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
+
       "integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "import-meta-resolve": "^4.1.0"
+
       },
+
       "peerDependencies": {
+
         "@sveltejs/kit": "^2.0.0"
+
       }
+
     },
+
     "node_modules/@sveltejs/kit": {
+
       "version": "2.42.2",
+
       "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.42.2.tgz",
+
       "integrity": "sha512-FcNICFvlSYjPiAgk8BpqTEnXkaUj6I6wDwpQBxKMpsYhUc2Q5STgsVpXOG5LqwFpUAoLAXQ4wdWul7EcAG67JQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@standard-schema/spec": "^1.0.0",
+
         "@sveltejs/acorn-typescript": "^1.0.5",
+
         "@types/cookie": "^0.6.0",
+
         "acorn": "^8.14.1",
+
         "cookie": "^0.6.0",
+
         "devalue": "^5.3.2",
+
         "esm-env": "^1.2.2",
+
         "kleur": "^4.1.5",
+
         "magic-string": "^0.30.5",
+
         "mrmime": "^2.0.0",
+
         "sade": "^1.8.1",
+
         "set-cookie-parser": "^2.6.0",
+
         "sirv": "^3.0.0"
+
       },
+
       "bin": {
+
         "svelte-kit": "svelte-kit.js"
+
       },
+
       "engines": {
+
         "node": ">=18.13"
+
       },
+
       "peerDependencies": {
+
         "@opentelemetry/api": "^1.0.0",
+
         "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+
         "svelte": "^4.0.0 || ^5.0.0-next.0",
+
         "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+
       },
+
       "peerDependenciesMeta": {
+
         "@opentelemetry/api": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/@sveltejs/vite-plugin-svelte": {
+
       "version": "3.1.2",
+
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
+
         "debug": "^4.3.4",
+
         "deepmerge": "^4.3.1",
+
         "kleur": "^4.1.5",
+
         "magic-string": "^0.30.10",
+
         "svelte-hmr": "^0.16.0",
+
         "vitefu": "^0.2.5"
+
       },
+
       "engines": {
+
         "node": "^18.0.0 || >=20"
+
       },
+
       "peerDependencies": {
+
         "svelte": "^4.0.0 || ^5.0.0-next.0",
+
         "vite": "^5.0.0"
+
       }
+
     },
+
     "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+
       "version": "2.1.0",
+
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
+
       "integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "debug": "^4.3.4"
+
       },
+
       "engines": {
+
         "node": "^18.0.0 || >=20"
+
       },
+
       "peerDependencies": {
+
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
+
         "svelte": "^4.0.0 || ^5.0.0-next.0",
+
         "vite": "^5.0.0"
+
       }
+
     },
+
     "node_modules/@testing-library/dom": {
+
       "version": "10.4.1",
+
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@babel/code-frame": "^7.10.4",
+
         "@babel/runtime": "^7.12.5",
+
         "@types/aria-query": "^5.0.1",
+
         "aria-query": "5.3.0",
+
         "dom-accessibility-api": "^0.5.9",
+
         "lz-string": "^1.5.0",
+
         "picocolors": "1.1.1",
+
         "pretty-format": "^27.0.2"
+
       },
+
       "engines": {
+
         "node": ">=18"
+
       }
+
     },
+
     "node_modules/@testing-library/jest-dom": {
+
       "version": "6.8.0",
+
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+
       "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@adobe/css-tools": "^4.4.0",
+
         "aria-query": "^5.0.0",
+
         "css.escape": "^1.5.1",
+
         "dom-accessibility-api": "^0.6.3",
+
         "picocolors": "^1.1.1",
+
         "redent": "^3.0.0"
+
       },
+
       "engines": {
+
         "node": ">=14",
+
         "npm": ">=6",
+
         "yarn": ">=1"
+
       }
+
     },
+
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+
       "version": "0.6.3",
+
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@testing-library/svelte": {
+
       "version": "5.2.8",
+
       "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.2.8.tgz",
+
       "integrity": "sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@testing-library/dom": "9.x.x || 10.x.x"
+
       },
+
       "engines": {
+
         "node": ">= 10"
+
       },
+
       "peerDependencies": {
+
         "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+
         "vite": "*",
+
         "vitest": "*"
+
       },
+
       "peerDependenciesMeta": {
+
         "vite": {
+
           "optional": true
+
         },
+
         "vitest": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/@testing-library/user-event": {
+
       "version": "14.6.1",
+
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=12",
+
         "npm": ">=6"
+
       },
+
       "peerDependencies": {
+
         "@testing-library/dom": ">=7.21.4"
+
       }
+
     },
+
     "node_modules/@types/aria-query": {
+
       "version": "5.0.4",
+
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@types/chai": {
+
       "version": "5.2.2",
+
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+
       "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/deep-eql": "*"
+
       }
+
     },
+
     "node_modules/@types/cookie": {
+
       "version": "0.6.0",
+
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@types/deep-eql": {
+
       "version": "4.0.2",
+
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@types/estree": {
+
       "version": "1.0.8",
+
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/@vitest/expect": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/chai": "^5.2.2",
+
         "@vitest/spy": "3.2.4",
+
         "@vitest/utils": "3.2.4",
+
         "chai": "^5.2.0",
+
         "tinyrainbow": "^2.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/@vitest/mocker": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@vitest/spy": "3.2.4",
+
         "estree-walker": "^3.0.3",
+
         "magic-string": "^0.30.17"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       },
+
       "peerDependencies": {
+
         "msw": "^2.4.9",
+
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
       },
+
       "peerDependenciesMeta": {
+
         "msw": {
+
           "optional": true
+
         },
+
         "vite": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/@vitest/pretty-format": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "tinyrainbow": "^2.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/@vitest/runner": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@vitest/utils": "3.2.4",
+
         "pathe": "^2.0.3",
+
         "strip-literal": "^3.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/@vitest/snapshot": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@vitest/pretty-format": "3.2.4",
+
         "magic-string": "^0.30.17",
+
         "pathe": "^2.0.3"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/@vitest/spy": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+
       "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "tinyspy": "^4.0.3"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/@vitest/ui": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
+
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@vitest/utils": "3.2.4",
+
         "fflate": "^0.8.2",
+
         "flatted": "^3.3.3",
+
         "pathe": "^2.0.3",
+
         "sirv": "^3.0.1",
+
         "tinyglobby": "^0.2.14",
+
         "tinyrainbow": "^2.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       },
+
       "peerDependencies": {
+
         "vitest": "3.2.4"
+
       }
+
     },
+
     "node_modules/@vitest/utils": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@vitest/pretty-format": "3.2.4",
+
         "loupe": "^3.1.4",
+
         "tinyrainbow": "^2.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/acorn": {
+
       "version": "8.15.0",
+
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "bin": {
+
         "acorn": "bin/acorn"
+
       },
+
       "engines": {
+
         "node": ">=0.4.0"
+
       }
+
     },
+
     "node_modules/ansi-regex": {
+
       "version": "5.0.1",
+
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     },
+
     "node_modules/ansi-styles": {
+
       "version": "5.2.0",
+
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=10"
+
       },
+
       "funding": {
+
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+
       }
+
     },
+
     "node_modules/aria-query": {
+
       "version": "5.3.0",
+
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+
       "dev": true,
+
       "license": "Apache-2.0",
+
       "dependencies": {
+
         "dequal": "^2.0.3"
+
       }
+
     },
+
     "node_modules/assertion-error": {
+
       "version": "2.0.1",
+
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/axobject-query": {
+
       "version": "4.1.0",
+
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+
       "dev": true,
+
       "license": "Apache-2.0",
+
       "engines": {
+
         "node": ">= 0.4"
+
       }
+
     },
+
     "node_modules/cac": {
+
       "version": "6.7.14",
+
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     },
+
     "node_modules/chai": {
+
       "version": "5.3.3",
+
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "assertion-error": "^2.0.1",
+
         "check-error": "^2.1.1",
+
         "deep-eql": "^5.0.1",
+
         "loupe": "^3.1.0",
+
         "pathval": "^2.0.0"
+
       },
+
       "engines": {
+
         "node": ">=18"
+
       }
+
     },
+
     "node_modules/check-error": {
+
       "version": "2.1.1",
+
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">= 16"
+
       }
+
     },
+
     "node_modules/code-red": {
+
       "version": "1.0.4",
+
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+
       "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@jridgewell/sourcemap-codec": "^1.4.15",
+
         "@types/estree": "^1.0.1",
+
         "acorn": "^8.10.0",
+
         "estree-walker": "^3.0.3",
+
         "periscopic": "^3.1.0"
+
       }
+
     },
+
     "node_modules/cookie": {
+
       "version": "0.6.0",
+
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">= 0.6"
+
       }
+
     },
+
     "node_modules/css-tree": {
+
       "version": "2.3.1",
+
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "mdn-data": "2.0.30",
+
         "source-map-js": "^1.0.1"
+
       },
+
       "engines": {
+
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+
       }
+
     },
+
     "node_modules/css.escape": {
+
       "version": "1.5.1",
+
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/debug": {
+
       "version": "4.4.3",
+
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "ms": "^2.1.3"
+
       },
+
       "engines": {
+
         "node": ">=6.0"
+
       },
+
       "peerDependenciesMeta": {
+
         "supports-color": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/deep-eql": {
+
       "version": "5.0.2",
+
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6"
+
       }
+
     },
+
     "node_modules/deepmerge": {
+
       "version": "4.3.1",
+
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=0.10.0"
+
       }
+
     },
+
     "node_modules/dequal": {
+
       "version": "2.0.3",
+
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6"
+
       }
+
     },
+
     "node_modules/devalue": {
+
       "version": "5.3.2",
+
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+
       "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/dom-accessibility-api": {
+
       "version": "0.5.16",
+
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/entities": {
+
       "version": "4.5.0",
+
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+
       "dev": true,
+
       "license": "BSD-2-Clause",
+
       "engines": {
+
         "node": ">=0.12"
+
       },
+
       "funding": {
+
         "url": "https://github.com/fb55/entities?sponsor=1"
+
       }
+
     },
+
     "node_modules/es-module-lexer": {
+
       "version": "1.7.0",
+
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/esbuild": {
+
       "version": "0.21.5",
+
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+
       "dev": true,
+
       "hasInstallScript": true,
+
       "license": "MIT",
+
       "bin": {
+
         "esbuild": "bin/esbuild"
+
       },
+
       "engines": {
+
         "node": ">=12"
+
       },
+
       "optionalDependencies": {
+
         "@esbuild/aix-ppc64": "0.21.5",
+
         "@esbuild/android-arm": "0.21.5",
+
         "@esbuild/android-arm64": "0.21.5",
+
         "@esbuild/android-x64": "0.21.5",
+
         "@esbuild/darwin-arm64": "0.21.5",
+
         "@esbuild/darwin-x64": "0.21.5",
+
         "@esbuild/freebsd-arm64": "0.21.5",
+
         "@esbuild/freebsd-x64": "0.21.5",
+
         "@esbuild/linux-arm": "0.21.5",
+
         "@esbuild/linux-arm64": "0.21.5",
+
         "@esbuild/linux-ia32": "0.21.5",
+
         "@esbuild/linux-loong64": "0.21.5",
+
         "@esbuild/linux-mips64el": "0.21.5",
+
         "@esbuild/linux-ppc64": "0.21.5",
+
         "@esbuild/linux-riscv64": "0.21.5",
+
         "@esbuild/linux-s390x": "0.21.5",
+
         "@esbuild/linux-x64": "0.21.5",
+
         "@esbuild/netbsd-x64": "0.21.5",
+
         "@esbuild/openbsd-x64": "0.21.5",
+
         "@esbuild/sunos-x64": "0.21.5",
+
         "@esbuild/win32-arm64": "0.21.5",
+
         "@esbuild/win32-ia32": "0.21.5",
+
         "@esbuild/win32-x64": "0.21.5"
+
       }
+
     },
+
     "node_modules/esm-env": {
+
       "version": "1.2.2",
+
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/estree-walker": {
+
       "version": "3.0.3",
+
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/estree": "^1.0.0"
+
       }
+
     },
+
     "node_modules/expect-type": {
+
       "version": "1.2.2",
+
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+
       "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+
       "dev": true,
+
       "license": "Apache-2.0",
+
       "engines": {
+
         "node": ">=12.0.0"
+
       }
+
     },
+
     "node_modules/fdir": {
+
       "version": "6.5.0",
+
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=12.0.0"
+
       },
+
       "peerDependencies": {
+
         "picomatch": "^3 || ^4"
+
       },
+
       "peerDependenciesMeta": {
+
         "picomatch": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/fflate": {
+
       "version": "0.8.2",
+
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/flatted": {
+
       "version": "3.3.3",
+
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+
       "dev": true,
+
       "license": "ISC"
+
     },
+
     "node_modules/fsevents": {
+
       "version": "2.3.3",
+
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+
       "dev": true,
+
       "hasInstallScript": true,
+
       "license": "MIT",
+
       "optional": true,
+
       "os": [
+
         "darwin"
+
       ],
+
       "engines": {
+
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+
       }
+
     },
+
     "node_modules/happy-dom": {
+
       "version": "13.10.1",
+
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-13.10.1.tgz",
+
       "integrity": "sha512-9GZLEFvQL5EgfJX2zcBgu1nsPUn98JF/EiJnSfQbdxI6YEQGqpd09lXXxOmYonRBIEFz9JlGCOiPflDzgS1p8w==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "entities": "^4.5.0",
+
         "webidl-conversions": "^7.0.0",
+
         "whatwg-mimetype": "^3.0.0"
+
       },
+
       "engines": {
+
         "node": ">=16.0.0"
+
       }
+
     },
+
     "node_modules/import-meta-resolve": {
+
       "version": "4.2.0",
+
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+
       "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "funding": {
+
         "type": "github",
+
         "url": "https://github.com/sponsors/wooorm"
+
       }
+
     },
+
     "node_modules/indent-string": {
+
       "version": "4.0.0",
+
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     },
+
     "node_modules/is-reference": {
+
       "version": "3.0.3",
+
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/estree": "^1.0.6"
+
       }
+
     },
+
     "node_modules/js-tokens": {
+
       "version": "4.0.0",
+
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/kleur": {
+
       "version": "4.1.5",
+
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6"
+
       }
+
     },
+
     "node_modules/locate-character": {
+
       "version": "3.0.0",
+
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/loupe": {
+
       "version": "3.2.1",
+
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/lz-string": {
+
       "version": "1.5.0",
+
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "bin": {
+
         "lz-string": "bin/bin.js"
+
       }
+
     },
+
     "node_modules/magic-string": {
+
       "version": "0.30.19",
+
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+
       "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@jridgewell/sourcemap-codec": "^1.5.5"
+
       }
+
     },
+
     "node_modules/mdn-data": {
+
       "version": "2.0.30",
+
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+
       "dev": true,
+
       "license": "CC0-1.0"
+
     },
+
     "node_modules/min-indent": {
+
       "version": "1.0.1",
+
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=4"
+
       }
+
     },
+
     "node_modules/mri": {
+
       "version": "1.2.0",
+
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=4"
+
       }
+
     },
+
     "node_modules/mrmime": {
+
       "version": "2.0.1",
+
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=10"
+
       }
+
     },
+
     "node_modules/ms": {
+
       "version": "2.1.3",
+
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/nanoid": {
+
       "version": "3.3.11",
+
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+
       "dev": true,
+
       "funding": [
+
         {
+
           "type": "github",
+
           "url": "https://github.com/sponsors/ai"
+
         }
+
       ],
+
       "license": "MIT",
+
       "bin": {
+
         "nanoid": "bin/nanoid.cjs"
+
       },
+
       "engines": {
+
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+
       }
+
     },
+
     "node_modules/pathe": {
+
       "version": "2.0.3",
+
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/pathval": {
+
       "version": "2.0.1",
+
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">= 14.16"
+
       }
+
     },
+
     "node_modules/periscopic": {
+
       "version": "3.1.0",
+
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+
       "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/estree": "^1.0.0",
+
         "estree-walker": "^3.0.0",
+
         "is-reference": "^3.0.0"
+
       }
+
     },
+
     "node_modules/picocolors": {
+
       "version": "1.1.1",
+
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+
       "dev": true,
+
       "license": "ISC"
+
     },
+
     "node_modules/picomatch": {
+
       "version": "4.0.3",
+
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=12"
+
       },
+
       "funding": {
+
         "url": "https://github.com/sponsors/jonschlinkert"
+
       }
+
     },
+
     "node_modules/postcss": {
+
       "version": "8.5.6",
+
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+
       "dev": true,
+
       "funding": [
+
         {
+
           "type": "opencollective",
+
           "url": "https://opencollective.com/postcss/"
+
         },
+
         {
+
           "type": "tidelift",
+
           "url": "https://tidelift.com/funding/github/npm/postcss"
+
         },
+
         {
+
           "type": "github",
+
           "url": "https://github.com/sponsors/ai"
+
         }
+
       ],
+
       "license": "MIT",
+
       "dependencies": {
+
         "nanoid": "^3.3.11",
+
         "picocolors": "^1.1.1",
+
         "source-map-js": "^1.2.1"
+
       },
+
       "engines": {
+
         "node": "^10 || ^12 || >=14"
+
       }
+
     },
+
     "node_modules/pretty-format": {
+
       "version": "27.5.1",
+
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "ansi-regex": "^5.0.1",
+
         "ansi-styles": "^5.0.0",
+
         "react-is": "^17.0.1"
+
       },
+
       "engines": {
+
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+
       }
+
     },
+
     "node_modules/react-is": {
+
       "version": "17.0.2",
+
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/redent": {
+
       "version": "3.0.0",
+
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "indent-string": "^4.0.0",
+
         "strip-indent": "^3.0.0"
+
       },
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     },
+
     "node_modules/rollup": {
+
       "version": "4.52.0",
+
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.0.tgz",
+
       "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/estree": "1.0.8"
+
       },
+
       "bin": {
+
         "rollup": "dist/bin/rollup"
+
       },
+
       "engines": {
+
         "node": ">=18.0.0",
+
         "npm": ">=8.0.0"
+
       },
+
       "optionalDependencies": {
+
         "@rollup/rollup-android-arm-eabi": "4.52.0",
+
         "@rollup/rollup-android-arm64": "4.52.0",
+
         "@rollup/rollup-darwin-arm64": "4.52.0",
+
         "@rollup/rollup-darwin-x64": "4.52.0",
+
         "@rollup/rollup-freebsd-arm64": "4.52.0",
+
         "@rollup/rollup-freebsd-x64": "4.52.0",
+
         "@rollup/rollup-linux-arm-gnueabihf": "4.52.0",
+
         "@rollup/rollup-linux-arm-musleabihf": "4.52.0",
+
         "@rollup/rollup-linux-arm64-gnu": "4.52.0",
+
         "@rollup/rollup-linux-arm64-musl": "4.52.0",
+
         "@rollup/rollup-linux-loong64-gnu": "4.52.0",
+
         "@rollup/rollup-linux-ppc64-gnu": "4.52.0",
+
         "@rollup/rollup-linux-riscv64-gnu": "4.52.0",
+
         "@rollup/rollup-linux-riscv64-musl": "4.52.0",
+
         "@rollup/rollup-linux-s390x-gnu": "4.52.0",
+
         "@rollup/rollup-linux-x64-gnu": "4.52.0",
+
         "@rollup/rollup-linux-x64-musl": "4.52.0",
+
         "@rollup/rollup-openharmony-arm64": "4.52.0",
+
         "@rollup/rollup-win32-arm64-msvc": "4.52.0",
+
         "@rollup/rollup-win32-ia32-msvc": "4.52.0",
+
         "@rollup/rollup-win32-x64-gnu": "4.52.0",
+
         "@rollup/rollup-win32-x64-msvc": "4.52.0",
+
         "fsevents": "~2.3.2"
+
       }
+
     },
+
     "node_modules/sade": {
+
       "version": "1.8.1",
+
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "mri": "^1.1.0"
+
       },
+
       "engines": {
+
         "node": ">=6"
+
       }
+
     },
+
     "node_modules/set-cookie-parser": {
+
       "version": "2.7.1",
+
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/siginfo": {
+
       "version": "2.0.0",
+
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+
       "dev": true,
+
       "license": "ISC"
+
     },
+
     "node_modules/sirv": {
+
       "version": "3.0.2",
+
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+
       "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@polka/url": "^1.0.0-next.24",
+
         "mrmime": "^2.0.0",
+
         "totalist": "^3.0.0"
+
       },
+
       "engines": {
+
         "node": ">=18"
+
       }
+
     },
+
     "node_modules/source-map-js": {
+
       "version": "1.2.1",
+
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+
       "dev": true,
+
       "license": "BSD-3-Clause",
+
       "engines": {
+
         "node": ">=0.10.0"
+
       }
+
     },
+
     "node_modules/stackback": {
+
       "version": "0.0.2",
+
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/std-env": {
+
       "version": "3.9.0",
+
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/strip-indent": {
+
       "version": "3.0.0",
+
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "min-indent": "^1.0.0"
+
       },
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     },
+
     "node_modules/strip-literal": {
+
       "version": "3.0.0",
+
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+
       "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "js-tokens": "^9.0.1"
+
       },
+
       "funding": {
+
         "url": "https://github.com/sponsors/antfu"
+
       }
+
     },
+
     "node_modules/strip-literal/node_modules/js-tokens": {
+
       "version": "9.0.1",
+
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/svelte": {
+
       "version": "4.2.20",
+
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@ampproject/remapping": "^2.2.1",
+
         "@jridgewell/sourcemap-codec": "^1.4.15",
+
         "@jridgewell/trace-mapping": "^0.3.18",
+
         "@types/estree": "^1.0.1",
+
         "acorn": "^8.9.0",
+
         "aria-query": "^5.3.0",
+
         "axobject-query": "^4.0.0",
+
         "code-red": "^1.0.3",
+
         "css-tree": "^2.3.1",
+
         "estree-walker": "^3.0.3",
+
         "is-reference": "^3.0.1",
+
         "locate-character": "^3.0.0",
+
         "magic-string": "^0.30.4",
+
         "periscopic": "^3.1.0"
+
       },
+
       "engines": {
+
         "node": ">=16"
+
       }
+
     },
+
     "node_modules/svelte-hmr": {
+
       "version": "0.16.0",
+
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
+
       "integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
+
       "dev": true,
+
       "license": "ISC",
+
       "engines": {
+
         "node": "^12.20 || ^14.13.1 || >= 16"
+
       },
+
       "peerDependencies": {
+
         "svelte": "^3.19.0 || ^4.0.0"
+
       }
+
     },
+
     "node_modules/tinybench": {
+
       "version": "2.9.0",
+
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/tinyexec": {
+
       "version": "0.3.2",
+
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+
       "dev": true,
+
       "license": "MIT"
+
     },
+
     "node_modules/tinyglobby": {
+
       "version": "0.2.15",
+
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "fdir": "^6.5.0",
+
         "picomatch": "^4.0.3"
+
       },
+
       "engines": {
+
         "node": ">=12.0.0"
+
       },
+
       "funding": {
+
         "url": "https://github.com/sponsors/SuperchupuDev"
+
       }
+
     },
+
     "node_modules/tinypool": {
+
       "version": "1.1.1",
+
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+
       "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": "^18.0.0 || >=20.0.0"
+
       }
+
     },
+
     "node_modules/tinyrainbow": {
+
       "version": "2.0.0",
+
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=14.0.0"
+
       }
+
     },
+
     "node_modules/tinyspy": {
+
       "version": "4.0.4",
+
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=14.0.0"
+
       }
+
     },
+
     "node_modules/totalist": {
+
       "version": "3.0.1",
+
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+
       "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=6"
+
       }
+
     },
+
     "node_modules/typescript": {
+
       "version": "5.9.2",
+
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+
       "dev": true,
+
       "license": "Apache-2.0",
+
       "bin": {
+
         "tsc": "bin/tsc",
+
         "tsserver": "bin/tsserver"
+
       },
+
       "engines": {
+
         "node": ">=14.17"
+
       }
+
     },
+
     "node_modules/vite": {
+
       "version": "5.4.20",
+
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "esbuild": "^0.21.3",
+
         "postcss": "^8.4.43",
+
         "rollup": "^4.20.0"
+
       },
+
       "bin": {
+
         "vite": "bin/vite.js"
+
       },
+
       "engines": {
+
         "node": "^18.0.0 || >=20.0.0"
+
       },
+
       "funding": {
+
         "url": "https://github.com/vitejs/vite?sponsor=1"
+
       },
+
       "optionalDependencies": {
+
         "fsevents": "~2.3.3"
+
       },
+
       "peerDependencies": {
+
         "@types/node": "^18.0.0 || >=20.0.0",
+
         "less": "*",
+
         "lightningcss": "^1.21.0",
+
         "sass": "*",
+
         "sass-embedded": "*",
+
         "stylus": "*",
+
         "sugarss": "*",
+
         "terser": "^5.4.0"
+
       },
+
       "peerDependenciesMeta": {
+
         "@types/node": {
+
           "optional": true
+
         },
+
         "less": {
+
           "optional": true
+
         },
+
         "lightningcss": {
+
           "optional": true
+
         },
+
         "sass": {
+
           "optional": true
+
         },
+
         "sass-embedded": {
+
           "optional": true
+
         },
+
         "stylus": {
+
           "optional": true
+
         },
+
         "sugarss": {
+
           "optional": true
+
         },
+
         "terser": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/vite-node": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+
       "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "cac": "^6.7.14",
+
         "debug": "^4.4.1",
+
         "es-module-lexer": "^1.7.0",
+
         "pathe": "^2.0.3",
+
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
       },
+
       "bin": {
+
         "vite-node": "vite-node.mjs"
+
       },
+
       "engines": {
+
         "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       }
+
     },
+
     "node_modules/vitefu": {
+
       "version": "0.2.5",
+
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+
       "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "peerDependencies": {
+
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+
       },
+
       "peerDependenciesMeta": {
+
         "vite": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/vitest": {
+
       "version": "3.2.4",
+
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "@types/chai": "^5.2.2",
+
         "@vitest/expect": "3.2.4",
+
         "@vitest/mocker": "3.2.4",
+
         "@vitest/pretty-format": "^3.2.4",
+
         "@vitest/runner": "3.2.4",
+
         "@vitest/snapshot": "3.2.4",
+
         "@vitest/spy": "3.2.4",
+
         "@vitest/utils": "3.2.4",
+
         "chai": "^5.2.0",
+
         "debug": "^4.4.1",
+
         "expect-type": "^1.2.1",
+
         "magic-string": "^0.30.17",
+
         "pathe": "^2.0.3",
+
         "picomatch": "^4.0.2",
+
         "std-env": "^3.9.0",
+
         "tinybench": "^2.9.0",
+
         "tinyexec": "^0.3.2",
+
         "tinyglobby": "^0.2.14",
+
         "tinypool": "^1.1.1",
+
         "tinyrainbow": "^2.0.0",
+
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+
         "vite-node": "3.2.4",
+
         "why-is-node-running": "^2.3.0"
+
       },
+
       "bin": {
+
         "vitest": "vitest.mjs"
+
       },
+
       "engines": {
+
         "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+
       },
+
       "funding": {
+
         "url": "https://opencollective.com/vitest"
+
       },
+
       "peerDependencies": {
+
         "@edge-runtime/vm": "*",
+
         "@types/debug": "^4.1.12",
+
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+
         "@vitest/browser": "3.2.4",
+
         "@vitest/ui": "3.2.4",
+
         "happy-dom": "*",
+
         "jsdom": "*"
+
       },
+
       "peerDependenciesMeta": {
+
         "@edge-runtime/vm": {
+
           "optional": true
+
         },
+
         "@types/debug": {
+
           "optional": true
+
         },
+
         "@types/node": {
+
           "optional": true
+
         },
+
         "@vitest/browser": {
+
           "optional": true
+
         },
+
         "@vitest/ui": {
+
           "optional": true
+
         },
+
         "happy-dom": {
+
           "optional": true
+
         },
+
         "jsdom": {
+
           "optional": true
+
         }
+
       }
+
     },
+
     "node_modules/webidl-conversions": {
+
       "version": "7.0.0",
+
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+
       "dev": true,
+
       "license": "BSD-2-Clause",
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/whatwg-mimetype": {
+
       "version": "3.0.0",
+
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+
       "dev": true,
+
       "license": "MIT",
+
       "engines": {
+
         "node": ">=12"
+
       }
+
     },
+
     "node_modules/why-is-node-running": {
+
       "version": "2.3.0",
+
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+
       "dev": true,
+
       "license": "MIT",
+
       "dependencies": {
+
         "siginfo": "^2.0.0",
+
         "stackback": "0.0.2"
+
       },
+
       "bin": {
+
         "why-is-node-running": "cli.js"
+
       },
+
       "engines": {
+
         "node": ">=8"
+
       }
+
     }
+
   }
+
 }
+

--- a/src/lib/questions/__tests__/NewQuestionPanel.test.ts
+++ b/src/lib/questions/__tests__/NewQuestionPanel.test.ts
@@ -2,6 +2,7 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 import NewQuestionPanel from '../NewQuestionPanel.svelte';
 


### PR DESCRIPTION
## Summary
- add an explicit vitest import for describe/expect/it in the NewQuestionPanel unit test
- refresh npm lockfile after installing test dependencies needed for the suite

## Testing
- npx vitest run src/lib/questions/__tests__/NewQuestionPanel.test.ts *(fails: suite requires a DOM environment and the Svelte component references undefined locals)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b3e80724832389dec2a6f3a2ae9b